### PR TITLE
[10.x] Fix `Undefined variable: $inline_file`

### DIFF
--- a/src/Services/Processors/Processor.php
+++ b/src/Services/Processors/Processor.php
@@ -143,7 +143,7 @@ abstract class Processor implements Contract
             $inline_file = $directory . '/' . $name . '-inline.' . $extension;
         }
 
-        $this->source_path = File::exists($path . '/' . $inline_file)
+        $this->source_path = $is_inline && File::exists($path . '/' . $inline_file)
             ? $path . '/' . $inline_file
             : $path . '/' . $filename;
     }


### PR DESCRIPTION
This PR fixes an uncaught exception when running `artisan lang:update` with `inline` configured to `false`. 

The exception was `Undefined variable: inline_filein src/Services/Processors/Processor.php:146`